### PR TITLE
[BREAKING CHANGE] Rename "id" prop to "client-id" (issue #18)

### DIFF
--- a/src/vue-timepicker.vue
+++ b/src/vue-timepicker.vue
@@ -15,7 +15,7 @@ export default {
     format: {type: String},
     minuteInterval: {type: Number},
     secondInterval: {type: Number},
-    id: {type: String}
+    inputId: {type: String}
   },
 
   data () {
@@ -373,7 +373,7 @@ export default {
 
 <template>
 <span class="time-picker">
-  <input class="display-time" :id="id" v-model="displayTime" @click.stop="toggleDropdown" type="text" readonly />
+  <input class="display-time" :id="inputId" v-model="displayTime" @click.stop="toggleDropdown" type="text" readonly />
   <span class="clear-btn" v-if="!hideClearButton" v-show="!showDropdown && showClearBtn" @click.stop="clearTime">&times;</span>
   <div class="time-picker-overlay" v-if="showDropdown" @click.stop="toggleDropdown"></div>
   <div class="dropdown" v-show="showDropdown">


### PR DESCRIPTION
This PR fixes the issue #18.

The "id" prop seems to be reserved by Vue. Pre-built library code in the dist directory are built with the id prop omitted.

Also the current specification is problematic, because we cannot specify id property to VueTimepicker component itself.