### PR TITLE
Allow users to add name prop

### DIFF
--- a/src/vue-timepicker.vue
+++ b/src/vue-timepicker.vue
@@ -15,7 +15,8 @@ export default {
     format: {type: String},
     minuteInterval: {type: Number},
     secondInterval: {type: Number},
-    id: {type: String}
+    id: {type: String},
+    name: {type: String}
   },
 
   data () {
@@ -373,7 +374,7 @@ export default {
 
 <template>
 <span class="time-picker">
-  <input class="display-time" :id="id" v-model="displayTime" @click.stop="toggleDropdown" type="text" readonly />
+  <input class="display-time" :id="id" :name="name" v-model="displayTime" @click.stop="toggleDropdown" type="text" readonly />
   <span class="clear-btn" v-if="!hideClearButton" v-show="!showDropdown && showClearBtn" @click.stop="clearTime">&times;</span>
   <div class="time-picker-overlay" v-if="showDropdown" @click.stop="toggleDropdown"></div>
   <div class="dropdown" v-show="showDropdown">


### PR DESCRIPTION
This PR would allow users to do: 

<vue-timepicker name="startTime" v-model="startTime"></vue-timepicker>

Which will in turn set the name attribute for the input, making it easier to work with forms.