### PR TITLE
Placeholder attribute refactor.

### DIFF
--- a/src/vue-timepicker.vue
+++ b/src/vue-timepicker.vue
@@ -1365,7 +1365,7 @@ export default {
          :id="id"
          :name="name"
          :value="inputIsEmpty ? null : customDisplayTime"
-         :placeholder="placeholder || formatString"
+         :placeholder="placeholder ? placeholder : formatString"
          :tabindex="disabled ? -1 : tabindex"
          :disabled="disabled"
          readonly


### PR DESCRIPTION
I was working with somebody with this Vue component and we couldn't get this placeholder to be set whenever we passed it in. I wanted to figure out why and saw that this attribute is bound through an OR statement. I have ran into this issue before and have realized that the OR statement is best used when you know that either object being passed in is acceptable, because if the values in the statement change the component doesn't reevaluate that statement for a new value. This is cause problems if there are unknown race conditions. 

With a ternary statement, Vue will usually reevaluate the statement and update as necessary if one of the values change. I think this will solve the problem we were running into and overwrite the formatString with the placeholder if it exists.