### PR TITLE
Stop propagation of toggleDropdown click

### DIFF
--- a/src/vue-timepicker.vue
+++ b/src/vue-timepicker.vue
@@ -1375,7 +1375,7 @@ export default {
          @blur="debounceBlur"
          @keydown.esc.exact="escBlur" />
   <span class="clear-btn" v-if="!showDropdown && showClearBtn" @click="clearTime" tabindex="-1">&times;</span>
-  <div class="time-picker-overlay" v-if="showDropdown" @click="toggleDropdown" tabindex="-1"></div>
+  <div class="time-picker-overlay" v-if="showDropdown" @click.stop="toggleDropdown" tabindex="-1"></div>
   <div class="dropdown" v-show="showDropdown" :style="inputWidthStyle" tabindex="-1" @mouseup="keepFocusing" @click.stop="">
     <div class="select-list" :style="inputWidthStyle" tabindex="-1">
       <!-- Common Keyboard Support: less event listeners -->


### PR DESCRIPTION
This (.time-picker-overlay) fixed layer triggers parent click, also after it is toggled, it isn't on the DOM anymore, its parent is null.